### PR TITLE
Fix miss-leading example

### DIFF
--- a/examples/shapes/shapes_to_coco.py
+++ b/examples/shapes/shapes_to_coco.py
@@ -60,7 +60,7 @@ def filter_for_annotations(root, files, image_filename):
     file_types = ['*.png']
     file_types = r'|'.join([fnmatch.translate(x) for x in file_types])
     basename_no_extension = os.path.splitext(os.path.basename(image_filename))[0]
-    file_name_prefix = basename_no_extension + '.*'
+    file_name_prefix = basename_no_extension + '_.*'
     files = [os.path.join(root, f) for f in files]
     files = [f for f in files if re.match(file_types, f)]
     files = [f for f in files if re.match(file_name_prefix, os.path.splitext(os.path.basename(f))[0])]


### PR DESCRIPTION
# Description
There is a potential bug in the given example, regarding the regular expression for file matching. This could lead to mismatching between image filenames and annotation filenames, which may cause serious confusion in the final COCO-format result. 

# Details
https://github.com/waspinator/pycococreator/blob/207b4fa8bbaae22ebcdeb3bbf00b724498e026a7/examples/shapes/shapes_to_coco.py#L63
The line above produces a regular expression for file matching image file with its annotation files. However, it might fail under certain circumstances. 

For example, if there are two images (1.jpg and 1000.jpg). The regular expression produced when finding the annotation files for 1.jpg will be `1.*`. Unfortunatly, this expression also includes annotation files coresponding to 1000.png

# Implemented fixed
Changed the regular expression from `basename.*` to `baseline_.*` sucessfully solved the problem, as long as the user sticks to the naming convention `basename_classname_instanceID` for annotation files.

#Note 
this bug does not affect the original example, but users modify the example for their custom dataset may trigger it and suffer from that. At least, it took me considerable time to figure that out. :)