### PR TITLE
Replaces git by https protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Read more here https://patrickwasp.com/create-your-own-coco-style-dataset/
 
 # Install
 
-`pip install git+git://github.com/waspinator/pycococreator.git@0.2.0`
+`pip install git+https://github.com/waspinator/pycococreator.git@0.2.0`
 
 If you need to install pycocotools for python 3, try the following:
 

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ If you need to install pycocotools for python 3, try the following:
 ```
 sudo apt-get install python3-dev
 pip install cython
-pip install git+git://github.com/waspinator/coco.git@2.1.0
+pip install git+https://github.com/waspinator/coco.git@2.1.0
 ```


### PR DESCRIPTION
Replaces git by https protocol

Fixes the error,

 The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
