### PR TITLE
Fix installation link from `git+git://...` to `git+https://...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Read more here https://patrickwasp.com/create-your-own-coco-style-dataset/
 
 # Install
 
-`pip install git+git://github.com/waspinator/pycococreator.git@0.2.0`
+`pip install git+https://github.com/waspinator/pycococreator.git@0.2.0`
 
 If you need to install pycocotools for python 3, try the following:
 
 ```
 sudo apt-get install python3-dev
 pip install cython
-pip install git+git://github.com/waspinator/coco.git@2.1.0
+pip install git+https://github.com/waspinator/coco.git@2.1.0
 ```


### PR DESCRIPTION
I've tried several times to install the library from the provided link and evry time failed for "Connection timed out".

The pip documentation says: "The use of git, git+git, and git+http schemes is discouraged. The former two use the Git Protocol, which lacks authentication, and HTTP is insecure due to lack of TLS based encryption."

If you want to check it out the documentation: https://pip.pypa.io/en/stable/topics/vcs-support/#supported-vcs

I 've changed the installation link from `git+git://...` to `git+https://...`. Now it worked!
Bye and thank tou!