### PR TITLE
Fix bug binary_mask_to_polygon when multiple contours of disjoint are…

### DIFF
--- a/pycococreatortools/pycococreatortools.py
+++ b/pycococreatortools/pycococreatortools.py
@@ -45,8 +45,9 @@ def binary_mask_to_polygon(binary_mask, tolerance=0):
     # pad mask to close contours of shapes which start and end at an edge
     padded_binary_mask = np.pad(binary_mask, pad_width=1, mode='constant', constant_values=0)
     contours = measure.find_contours(padded_binary_mask, 0.5)
-    contours = np.subtract(contours, 1)
+    
     for contour in contours:
+        contour = np.subtract(contour, 1)
         contour = close_contour(contour)
         contour = measure.approximate_polygon(contour, tolerance)
         if len(contour) < 3:


### PR DESCRIPTION
Fix a small bug inside the funciton binary_mask_to_polygon in pycocoreatortools.py The bug happened when multiple contours of disjoint areas were found. We cannot do np.subtract on multiple arrays of different sizes.

For example, if we have a mask like this one, it has multiple disjoint parts.

![image](https://github.com/user-attachments/assets/56acaf5a-b32e-4c92-99ea-d6e2f36522b0)
